### PR TITLE
Use apt repo from Sonarr docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ CMD ["/sbin/my_init"]
 
 # Configure nzbdrone's apt repository
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FDA5DFFC && \
-echo "deb http://update.nzbdrone.com/repos/apt/debian master main" >> /etc/apt/sources.list && \
+echo "deb http://apt.sonarr.tv/ master main" > /etc/apt/sources.list.d/sonarr.list && \
 apt-get update -q && \
 apt-get install -qy libmono-cil-dev python nzbdrone && \
 apt-get clean && \


### PR DESCRIPTION
This updates to use the apt repo listed in the official docs, and uses a separate apt repo file instead of appending to global sources.list.