### PR TITLE
Fix mono time issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ docker create \
 	--name sonarr \
 	-p 8989:8989 \
 	-e PUID=<UID> -e PGID=<GID> \
+	-v /dev/rtc:/dev/rtc:ro \
 	-v </path/to/appdata>:/config \
 	-v <path/to/tvseries>:/tv \
 	linuxserver/sonarr
@@ -23,6 +24,7 @@ docker create \
 **Parameters**
 
 * `-p 8989` - the port sonarr webinterface
+* `-v /dev/rtc:/dev/rtc:ro` - map hwclock to the docker hwclock as ReadOnly (mono throws exeptions otherwise)
 * `-v /config` - database and sonarr configs
 * `-v /tv` - location of TV library on disk
 * `-e PGID` for for GroupID - see below for explanation


### PR DESCRIPTION
If this rtc is not mapped mono throws issues and makes sonarr almost unusable

No rtc:
```
[...]
[Info] RefreshEpisodeService: Starting episode info refresh for: [259063][Hannibal]
EPIC FAIL: System.NullReferenceException: Object reference not set to an instance of an object
  at System.Threading.EventWaitHandle.Reset () [0x00000] in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) System.Threading.EventWaitHandle:Reset ()
  at System.Threading.Timer+Scheduler.SchedulerThread () [0x00000] in <filename unknown>:0
  at System.Threading.Thread.StartInternal () [0x00000] in <filename unknown>:0
[Info] RefreshEpisodeService: Finished episode refresh for series: [259063][Hannibal].
[Fatal] GlobalExceptionHandlers: EPIC FAIL: Object reference not set to an instance of an object

System.NullReferenceException: Object reference not set to an instance of an object
  at System.Threading.EventWaitHandle.Reset () [0x00000] in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) System.Threading.EventWaitHandle:Reset ()
  at System.Threading.Timer+Scheduler.SchedulerThread () [0x00000] in <filename unknown>:0
  at System.Threading.Thread.StartInternal () [0x00000] in <filename unknown>:0

[Info] DiskScanService: Scanning disk for Hannibal
[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
  at System.Threading.EventWaitHandle.Reset () [0x00000] in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) System.Threading.EventWaitHandle:Reset ()
  at System.Threading.Timer+Scheduler.SchedulerThread () [0x00000] in <filename unknown>:0
  at System.Threading.Thread.StartInternal () [0x00000] in <filename unknown>:0
```

at that point sonarr crashes and restarts and logs:
```
[Info] Bootstrap: Starting Sonarr - /opt/NzbDrone/NzbDrone.exe - Version 2.0.0.3357
[Info] AppFolderInfo: Data directory is being overridden to [/config]
[Debug] ProcessProvider: Found 0 processes with the name: NzbDrone.Console
[Debug] ProcessProvider: Found 1 processes with the name: NzbDrone
[Debug] ProcessProvider:  - [90] NzbDrone
[...]
```