### PR TITLE
Add download volume to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ docker create \
 	-v /dev/rtc:/dev/rtc:ro \
 	-v </path/to/appdata>:/config \
 	-v <path/to/tvseries>:/tv \
+  -v <path/to/downloadclient-downloads>:/downloads \
 	linuxserver/sonarr
 ```
 


### PR DESCRIPTION
updated readme to include the volume mount for the download client, without this you have to configure remote paths and other complicated solutions