### PR TITLE
Run mono with the debug switch

### DIFF
--- a/root/etc/services.d/sonarr/run
+++ b/root/etc/services.d/sonarr/run
@@ -5,5 +5,5 @@ umask 022
 cd /opt/NzbDrone || exit
 
 exec \
-	s6-setuidgid abc mono NzbDrone.exe \
+	s6-setuidgid abc mono --debug NzbDrone.exe \
 	-nobrowser -data=/config


### PR DESCRIPTION
I was troubleshooting an issue with Sonarr running in this docker image and noticed we don't have line numbers in stack traces which makes troubleshooting where the exception is being thrown almost impossible.