### PR TITLE
Fix for "Could not find file "/etc/localtime""

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker create \
 	--name sonarr \
 	-p 8989:8989 \
 	-e PUID=<UID> -e PGID=<GID> \
-	-v /dev/rtc:/dev/rtc:ro \
+	-v /etc/localtime:/etc/localtime:ro \
 	-v </path/to/appdata>:/config \
 	-v <path/to/tvseries>:/tv \
 	-v <path/to/downloadclient-downloads>:/downloads \


### PR DESCRIPTION
The create command broke in the last build. Sonarr now looks for /etc/localtime instead of /dev/rtc for timekeeping and the container refuses to start.
