### PR TITLE
Mono rebase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,19 @@
-FROM lsiobase/xenial
+FROM lsiobase/mono
 MAINTAINER sparklyballs
 
 # set environment variables
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV XDG_CONFIG_HOME="/config/xdg"
 
-# add sonarr and mono repositories
+# add sonarr repository
 RUN \
  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FDA5DFFC && \
  echo "deb http://apt.sonarr.tv/ master main" > \
 	/etc/apt/sources.list.d/sonarr.list && \
- apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-	--recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/debian wheezy main" \
-	| tee /etc/apt/sources.list.d/mono-xamarin.list && \
 
 # install packages
  apt-get update && \
  apt-get install -y \
-	libcurl3 \
 	nzbdrone && \
 
 # cleanup

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ docker create \
 	linuxserver/sonarr
 ```
 
+You can choose between ,using tags, various branch versions of sonarr, no tag is required to remain on the main branch.
+
+Add one of the tags,  if required,  to the linuxserver/sonarr line of the run/create command in the following format, linuxserver/sonarr:develop
+
+#### Tags
++ **develop**
++ **preview**
+
 ## Parameters
 
 `The parameters are split into two halves, separated by a colon, the left hand side representing the host and the right the container side. 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Access the webui at `<your-ip>:8989`, for more information check out [Sonarr](ht
 
 ## Changelog
 
-+ **17.04.17:** Switch to using inhouse mono baseimage.
++ **17.04.17:** Switch to using inhouse mono baseimage, adds python also.
 + **14.04.17:** Change to mount /etc/localtime in README, thanks cbgj.
 + **13.04.17:** Switch to official mono repository.
 + **30.09.16:** Fix umask

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ docker create \
 	--name sonarr \
 	-p 8989:8989 \
 	-e PUID=<UID> -e PGID=<GID> \
+	-e TZ=<timezone> \ 
 	-v /etc/localtime:/etc/localtime:ro \
 	-v </path/to/appdata>:/config \
 	-v <path/to/tvseries>:/tv \
@@ -43,13 +44,18 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 
 
 * `-p 8989` - the port sonarr webinterface
-* `-v /etc/localtime:/etc/localtime:ro` - map localtime as ReadOnly (mono throws exceptions otherwise)
 * `-v /config` - database and sonarr configs
 * `-v /tv` - location of TV library on disk
+* `-v /etc/localtime` for timesync - see [Localtime](#localtime) for important information
+* `-e TZ` for timezone information, Europe/London - see [Localtime](#localtime) for important information
 * `-e PGID` for for GroupID - see below for explanation
 * `-e PUID` for for UserID - see below for explanation
 
 It is based on ubuntu xenial with S6 overlay, for shell access whilst the container is running do `docker exec -it sonarr /bin/bash`.
+
+## Localtime
+
+It is important that you either set `-v /etc/localtime:/etc/localtime:ro` or the TZ variable, mono will throw exceptions without one of them set.
 
 ### User / Group Identifiers
 
@@ -71,6 +77,7 @@ Access the webui at `<your-ip>:8989`, for more information check out [Sonarr](ht
 
 ## Changelog
 
++ **17.04.17:** Switch to using inhouse mono baseimage.
 + **14.04.17:** Change to mount /etc/localtime in README, thanks cbgj.
 + **13.04.17:** Switch to official mono repository.
 + **30.09.16:** Fix umask

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Add one of the tags,  if required,  to the linuxserver/sonarr line of the run/cr
 
 #### Tags
 + **develop**
-+ **preview**
 
 ## Parameters
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ rebase to inhouse mono baseimage
+ adds 90MB to final image size though..
+ clarify notes in README about localtime issue with mono 4.8 + 
+ adds python inherited from mono baseimage for postprocessing scripts
+ closes #32