### PR TITLE
Add python3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
+ 	python3 \
 	nzbdrone && \
  echo "**** cleanup ****" && \
  apt-get clean && \


### PR DESCRIPTION
With the growing number of custom scripts out there it should be way past due to finally add python3 support to the sonarr/radarr/lidarr images. I'm using this locally from a fork and working wonderfully, but surely I cannot be the only in need of python3 with its growing adoption and support. 

If there is a higher level docker image that this should be pulled into and then propagated down to the sonarr/radarr/lidarr images, please let me know.

Just trying to give back to the team who builds and maintains the best images in the nine realms. :)