### PR TITLE
using 5.14 tag for mono base version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/mono:xenial
+FROM lsiobase/mono:5.14
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/mono.arm64:xenial
+FROM lsiobase/mono.arm64:5.14
 
 # Add qemu to build on x86_64 systems
 COPY qemu-aarch64-static /usr/bin

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/mono.armhf:xenial
+FROM lsiobase/mono.armhf:5.14
 
 # Add qemu to build on x86_64 systems
 COPY qemu-arm-static /usr/bin

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **09.02.19:** - Stick mono version at 5.14 stable
 * **01.02.19:** - Multi arch images and pipeline build logic
 * **15.12.17:** - Fix continuation lines.
 * **12.07.17:** - Add inspect commands to README, move to jenkins build and push.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -50,6 +50,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "09.02.19:", desc: "Stick mono version at 5.14 stable" }
   - { date: "01.02.19:", desc: "Multi arch images and pipeline build logic" }
   - { date: "15.12.17:", desc: "Fix continuation lines." }
   - { date: "12.07.17:", desc: "Add inspect commands to README, move to jenkins build and push." }


### PR DESCRIPTION
This needs testing along with review, it uses a mono base image at 5.14 stable.