### PR TITLE
Remove downloads and tv volumes from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8989
-VOLUME /config /downloads /tv
+VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -40,4 +40,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8989
-VOLUME /config /downloads /tv
+VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -40,4 +40,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8989
-VOLUME /config /downloads /tv
+VOLUME /config


### PR DESCRIPTION
## Description:

Specifying the volumes in the Dockerfile is unnecessary and can lead to excessive orphaned volume if the user chooses to use different paths at runtime.

## Benefits of this PR and context:

The `downloads` and `tv` volumes are actually not used by the initial container and are completely dependent on how users configure Sonarr.

Furthermore, Sonarr's [own documentation **discourages**](https://sonarr.tv/#downloads-v3-docker) using separate volumes for downloads and media and specifically calls it out as a common pitfall. Even the [best practices wiki page on the _/r/usenet_ subreddit](https://www.reddit.com/r/usenet/wiki/docker#wiki_consistent_and_well_planned_paths) discourages the default volume setup.

This also allows user the flexibility to use the same volume for downloads and media (to solve the hardlink issue - see #34) without having the container create unnecessary volumes.

Removing the volumes from the Dockerfile does not prevent users from having the README instructions succeed, but does allow for more flexibility without the creation of unnecessary unused volumes.

## How Has This Been Tested?

Built the docker container and verified no extra volumes were created.

## Source / References:
* https://sonarr.tv/#downloads-v3-docker
* https://www.reddit.com/r/usenet/wiki/docker#wiki_consistent_and_well_planned_paths
* #34